### PR TITLE
[FIX] Fix crash on launch by disabling new architecture

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",


### PR DESCRIPTION
This pull request includes a small change to the `app.json` configuration file. The change disables the `newArchEnabled` feature by setting its value from `true` to `false`.