### PR TITLE
Add bottom tab navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 import { StatusBar } from 'expo-status-bar';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import TimetableScreen from './screens/TimetableScreen';
 import RoomsScreen from './screens/RoomsScreen';
 import GradesScreen from './screens/GradesScreen';
@@ -11,7 +12,21 @@ export default function App() {
   return (
     <NavigationContainer>
       <StatusBar style="auto" />
-      <Tab.Navigator>
+      <Tab.Navigator
+        screenOptions={({ route }) => ({
+          tabBarIcon: ({ color, size }) => {
+            let iconName: keyof typeof Ionicons.glyphMap;
+            if (route.name === 'Emploi du temps') {
+              iconName = 'calendar-outline';
+            } else if (route.name === 'Salles') {
+              iconName = 'school-outline';
+            } else {
+              iconName = 'document-text-outline';
+            }
+            return <Ionicons name={iconName} size={size} color={color} />;
+          },
+        })}
+      >
         <Tab.Screen name="Emploi du temps" component={TimetableScreen} />
         <Tab.Screen name="Salles" component={RoomsScreen} />
         <Tab.Screen name="Notes" component={GradesScreen} />

--- a/App.tsx
+++ b/App.tsx
@@ -1,20 +1,21 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import TimetableScreen from './screens/TimetableScreen';
+import RoomsScreen from './screens/RoomsScreen';
+import GradesScreen from './screens/GradesScreen';
+
+const Tab = createBottomTabNavigator();
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
+    <NavigationContainer>
       <StatusBar style="auto" />
-    </View>
+      <Tab.Navigator>
+        <Tab.Screen name="Emploi du temps" component={TimetableScreen} />
+        <Tab.Screen name="Salles" component={RoomsScreen} />
+        <Tab.Screen name="Notes" component={GradesScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.2",
-    "react-native-reanimated": "~3.17.4"
+    "react-native-reanimated": "~3.17.4",
+    "@react-navigation/native": "^6.1.8",
+    "@react-navigation/bottom-tabs": "^6.5.8",
+    "react-native-safe-area-context": "^4.8.0",
+    "react-native-screens": "^3.25.0"
   },
   "devDependencies": {
     "@babel/core": "^7.27.1",

--- a/screens/GradesScreen.tsx
+++ b/screens/GradesScreen.tsx
@@ -1,0 +1,17 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function GradesScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Grades Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/screens/RoomsScreen.tsx
+++ b/screens/RoomsScreen.tsx
@@ -1,0 +1,17 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function RoomsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Available Rooms Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/screens/TimetableScreen.tsx
+++ b/screens/TimetableScreen.tsx
@@ -1,0 +1,17 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function TimetableScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Timetable Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add navigation dependencies
- implement bottom tab navigator with three screens
- create placeholder screens for timetable, rooms and grades

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68402c6fd79883249a857dffd4bc5cdc